### PR TITLE
Adding OPAL to the Open-source policy frameworks

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -393,6 +393,8 @@ Collection of open-source projects if you're looking to roll your own policy imp
 
 - [Open Policy Agent](https://github.com/open-policy-agent) - Allows end to end testing of your policies across SQL, Kubernetes, Terraform, Kafka, Envoy, S3 (via Minio), EC2/ECS/Lambda (Linux).
 
+- [Open Policy Administration Layer](https://github.com/permitio/opal) - Open Source administration layer for OPA, detecting changes to both policy and policy data in realtime and pushing live updates to OPA agents. OPAL brings open-policy up to the speed needed by live applications.
+
 - [Gubernator](https://github.com/mailgun/gubernator) - High performance rate-limiting micro-service and library.
 
 - [Biscuit](https://www.clever-cloud.com/blog/engineering/2021/04/12/introduction-to-biscuit/) - Biscuit merge concepts from cookies, JWTs, macaroons and Open Policy Agent. “It provide a logic language based on Datalog to write authorization policies. It can store data, like JWT, or small conditions like Macaroons, but it is also able to represent more complex rules like role-based access control, delegation, hierarchies.”


### PR DESCRIPTION
#### Preliminary checks

- [x] I have [read the Code of Conduct](https://github.com/kdeldycke/awesome-iam/blob/main/.github/code-of-conduct.md)
- [x] I applied all rules from the [Contributing guide](https://github.com/kdeldycke/awesome-iam/blob/main/.github/contributing.md)
- [x] I have checked there is no other [Issues](https://github.com/kdeldycke/awesome-iam/issues) or [Pull Requests](https://github.com/kdeldycke/awesome-iam/pulls) covering the same topic to open

#### Summary

<!-- You can skip this if you're proposing something as trivial as fixing a typo -->

Explain the motivation for making this change. What does this bring to the table?

Hey and thank you for considering my contribution!

I suggest adding OPAL to the AuthZ realm. OPAL is an administration layer on top of OPA that makes OPA usable for the application layer, keeping multiple OPA agents synced in real-time with policy and data updates.

