### PR TITLE
docs(ZITADEL): rename caos to zitadel

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -329,7 +329,7 @@ The old *OpenID* is dead; the new *OpenID Connect* is very much not-dead.
 
 - [authentik](https://goauthentik.io/?#correctness) - Open-source Identity Provider similar to Keycloak.
 
-- [ZITADEL](https://github.com/caos/zitadel) - An Open-Source solution built with Go and Angular to manage all your systems, users and service accounts together with their roles and external identities. ZITADEL provides you with OIDC, OAuth 2.0, login & register flows, passwordless and MFA authentication. All this is built on top of eventsourcing in combination with CQRS to provide a great audit trail.
+- [ZITADEL](https://github.com/zitadel/zitadel) - An Open-Source solution built with Go and Angular to manage all your systems, users and service accounts together with their roles and external identities. ZITADEL provides you with OIDC, OAuth 2.0, login & register flows, passwordless and MFA authentication. All this is built on top of eventsourcing in combination with CQRS to provide a great audit trail.
 
 ### SAML
 


### PR DESCRIPTION
Hi there - we did move caos/zitadel to zitadel/zitadel and would like to update this link 😁

#### Preliminary checks

- [x ] I have [read the Code of Conduct](https://github.com/kdeldycke/awesome-iam/blob/main/.github/code-of-conduct.md)
- [x] I applied all rules from the [Contributing guide](https://github.com/kdeldycke/awesome-iam/blob/main/.github/contributing.md)
- [x] I have checked there is not other [Issues](https://github.com/kdeldycke/awesome-iam/issues) or [Pull Requests](https://github.com/kdeldycke/awesome-iam/pulls) covering the same topic to open

#### Summary

<!-- You can skip this if you're proposing something as trivial as fixing a typo -->

Explain the motivation for making this change. What does does this bring to the table?
