### PR TITLE
Added aws-lint-iam-policies

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -478,6 +478,8 @@ Tools and resources exclusively targetting the [AWS IAM policies](http://docs.aw
 
 - [IAMbic](https://github.com/noqdev/iambic) - GitOps for IAM. The Terraform of Cloud IAM. IAMbic is a multi-cloud identity and access management (IAM) control plane that centralizes and simplifies cloud access and permissions. It maintains an eventually consistent, human-readable, bi-directional representation of IAM in version control.
 
+- [aws-lint-iam-policies](https://github.com/welldone-cloud/aws-lint-iam-policies) - Runs IAM policy linting checks against either a single AWS account or all accounts of an AWS Organization. Reports on policies that violate security best practices or contain errors. Supports both identity-based and resource-based policies.
+
 ### Macaroons
 
 A clever curiosity to distribute and delegate authorization.


### PR DESCRIPTION
### Motivation
This new link is special because...

aws-lint-iam-policies not just lints single IAM policy documents, but scales policy linting across many different AWS resource types (see [here](https://github.com/welldone-cloud/aws-lint-iam-policies#supported-policy-types)) and is capable of checking all accounts of an AWS Organization. 

### Affiliation

- [X] I am the author of the article or project
- [X] I am working for/with the company which is publishing the article or project
- [ ] I'm just a rando who stumbled upon this via social networks

### Self checks

- [X] I have [read the Code of Conduct](https://github.com/kdeldycke/awesome-iam/blob/main/.github/code-of-conduct.md)
- [X] I applied all rules from the [Contributing guide](https://github.com/kdeldycke/awesome-iam/blob/main/.github/contributing.md)
- [X] I have checked there is no other [Issues](https://github.com/kdeldycke/awesome-iam/issues) or [Pull Requests](https://github.com/kdeldycke/awesome-iam/pulls) covering the same topic to open
