### PR TITLE
add `dotenvx`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -543,6 +543,8 @@ Architectures, software and hardware allowing the storage and usage of secrets t
 
 - [`sops`](https://github.com/mozilla/sops) - Encrypts the values of YAML and JSON files, not the keys.
 
+- [`dotenvx`](https://github.com/dotenvx/dotenvx) - Similar to sops but for .env files – encrypts the values of .env files, not the keys.
+
 - [`gitleaks`](https://github.com/zricethezav/gitleaks) - Audit git repos for secrets.
 
 - [`truffleHog`](https://github.com/dxa4481/truffleHog) - Searches through git repositories for high entropy strings and secrets, digging deep into commit history.

--- a/readme.zh.md
+++ b/readme.zh.md
@@ -541,6 +541,8 @@ IAM 的基础：用户、组、角色和权限的定义和生命周期。
 
 - [`sops`](https://github.com/mozilla/sops) - 加密 YAML 和 JSON 文件的值，而不是密钥。
 
+- [`dotenvx`](https://github.com/dotenvx/dotenvx) - 类似于 sops，但用于 .env 文件——加密 .env 文件中的值，而不是密钥。
+
 - [`gitleaks`](https://github.com/zricethezav/gitleaks) - 审计 git repos 的秘密。
 
 - [`truffleHog`](https://github.com/dxa4481/truffleHog) - 在 git 存储库中搜索高熵字符串和秘密，深入挖掘提交历史。


### PR DESCRIPTION
### Motivation

Hi Kevin, for your consideration - `dotenvx`.

It's very similar to sops but for .env files. Encrypted values while keys stay decrypted. For example:

```
# .env
HELLO="encrypted:1234"
```

It's special because it has a pretty easy to use cli - just run `dotenvx encrypt` and it encrypts your .env file. It's more opinionated than sops, having already chosen the encryption algo. It's approach and reasoning is all laid out in its [whitepaper](https://dotenvx.com/dotenvx.pdf).

### Affiliation

Hi Kevin, I'm the creator of [`dotenvx`](https://github.com/dotenvx/dotenvx).

- [x] I am the author of the article or project

### Self checks

- [x] I have [read the Code of Conduct](https://github.com/kdeldycke/awesome-iam/blob/main/.github/code-of-conduct.md)
- [x] I applied all rules from the [Contributing guide](https://github.com/kdeldycke/awesome-iam/blob/main/.github/contributing.md)
- [x] I have checked there is no other [Issues](https://github.com/kdeldycke/awesome-iam/issues) or [Pull Requests](https://github.com/kdeldycke/awesome-iam/pulls) covering the same topic to open
