### PR TITLE
Add IAMDevBox PKCE Generator to OAuth2 & OpenID section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -455,6 +455,8 @@ The old *OpenID* is dead; the new *OpenID Connect* is very much not-dead.
 
 - [PKCE Explained](https://www.loginradius.com/blog/engineering/pkce/) - “PKCE is used to provide one more security layer to the authorization code flow in OAuth and OpenID Connect.”
 
+- [IAMDevBox PKCE Generator](https://www.iamdevbox.com/tools/pkce-generator/) - Online tool to generate PKCE code verifier and code challenge pairs for OAuth 2.0 and OpenID Connect authorization flows. Supports S256 and plain challenge methods.
+
 - [Hydra](https://github.com/ory/hydra) - Open-source OIDC & OAuth2 Server Provider.
 
 - [Keycloak](https://github.com/keycloak/keycloak) - Open-source Identity and Access Management. Supports OIDC, OAuth 2 and SAML 2, LDAP and AD directories, password policies.

--- a/readme.zh.md
+++ b/readme.zh.md
@@ -455,6 +455,8 @@ IAM 的基础：用户、组、角色和权限的定义和生命周期。
 
 - [PKCE 的解释](https://www.loginradius.com/blog/engineering/pkce/) - "PKCE 用于为 OAuth 和 OpenID Connect 中的授权代码流提供多一个安全层。"
 
+- [IAMDevBox PKCE 生成器](https://www.iamdevbox.com/tools/pkce-generator/) - 在线工具，用于生成 OAuth 2.0 和 OpenID Connect 授权流的 PKCE code verifier 和 code challenge 对。支持 S256 和 plain challenge 方法。
+
 - [Hydra](https://github.com/ory/hydra) - 开源 OIDC 和 OAuth2 服务器提供商。
 
 - [Keycloak](https://github.com/keycloak/keycloak) - 开源的身份和访问管理。支持 OIDC、OAuth 2和SAML 2、LDAP 和 AD 目录、密码策略。


### PR DESCRIPTION
Adds a free online PKCE code verifier/challenge generator tool to the OAuth2 & OpenID section, placed right after the existing "PKCE Explained" article.

**Why this addition is valuable:**

The section already links to an article explaining PKCE, but has no interactive tool for generating PKCE pairs. Developers implementing OAuth 2.0 with PKCE need to generate code_verifier and code_challenge values for testing. [IAMDevBox PKCE Generator](https://www.iamdevbox.com/tools/pkce-generator/) provides:

- Random code_verifier generation (RFC 7636 compliant)
- S256 and plain code_challenge computation
- Copy-to-clipboard for quick use in OAuth flows

This complements the existing "PKCE Explained" article by giving developers a hands-on tool to use alongside the conceptual explanation.