### PR TITLE
Add Scalekit to OAuth2 & OpenID section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -469,6 +469,8 @@ The old *OpenID* is dead; the new *OpenID Connect* is very much not-dead.
 
 - [Logto](https://github.com/logto-io/logto) - An IAM infrastructure for modern apps and SaaS products, supporting OIDC, OAuth 2.0 and SAML for authentication and authorization.
 
+- [Scalekit](https://scalekit.com) - Enterprise SSO and identity management platform with OIDC & OAuth 2.1 provider, SAML 2.0, SCIM provisioning, and OAuth token vault for AI agent authentication (Agent Auth).
+
 - [Authgear](https://github.com/authgear/authgear-server) - Open-source authentication-as-a-service solution. It includes the code for the server, AuthUI, the Portal, and Admin API.
 
 ## SAML


### PR DESCRIPTION
## What

Adds [Scalekit](https://scalekit.com) to the **OAuth2 & OpenID** section, after Authgear.

## Why

Scalekit is an authentication platform for B2B SaaS products. It supports enterprise SSO (SAML/OIDC), SCIM directory sync, and OAuth-based delegated access — including for AI agents. It is the only entry in the section specifically targeting the B2B SaaS use case, and adds coverage of OAuth delegation for AI agents that no other entry addresses.

## Checklist

- [x] One item, one commit
- [x] Both `readme.md` and `readme.zh.md` updated
- [x] Description ends with a period
- [x] HTTPS URL
- [x] No trailing whitespace