### PR TITLE
Add Cloud-IAM - managed Keycloak platform

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -461,6 +461,8 @@ The old *OpenID* is dead; the new *OpenID Connect* is very much not-dead.
 
 - [Casdoor](https://github.com/casbin/casdoor) - A UI-first centralized authentication / Single-Sign-On (SSO) platform based. Supports OIDC and OAuth 2, social logins, user management, 2FA based on Email and SMS.
 
+- [Cloud-IAM](https://cloud-iam.com) - Managed Keycloak SaaS platform with 70+ regions across 5 cloud providers. ISO 27001, SOC 2 Type 2, HDS, SecNumCloud 3.2 and GDPR compliant.
+
 - [authentik](https://github.com/goauthentik/authentik) - Open-source Identity Provider similar to Keycloak.
 
 - [ZITADEL](https://github.com/zitadel/zitadel) - An Open-Source solution built with Go and Angular to manage all your systems, users and service accounts together with their roles and external identities. ZITADEL provides you with OIDC, OAuth 2.0, login & register flows, passwordless and MFA authentication. All this is built on top of eventsourcing in combination with CQRS to provide a great audit trail.

--- a/readme.zh.md
+++ b/readme.zh.md
@@ -462,6 +462,8 @@ IAM 的基础：用户、组、角色和权限的定义和生命周期。
 
 - [Casdoor](https://github.com/casbin/casdoor) - 基于 UI 优先的集中式身份验证/单点登录 (SSO) 平台。 支持 OIDC 和 OAuth 2、社交登录、用户管理、基于电子邮件和短信的 2FA。
 
+- [Cloud-IAM](https://cloud-iam.com) - 托管的 Keycloak SaaS 平台，覆盖 5 个云提供商的 70 多个区域。通过 ISO 27001、SOC 2 Type 2、HDS、SecNumCloud 3.2 和 GDPR 认证。
+
 - [authentik](https://github.com/goauthentik/authentik) - 类似于 Keycloak 的开源身份提供者。
 
 - [ZITADEL](https://github.com/zitadel/zitadel) - 使用 Go 和 Angular 构建的开源解决方案，用于管理您的所有系统、用户和服务帐户及其角色和外部身份。 ZITADEL 为您提供 OIDC、OAuth 2.0、登录和注册流程、无密码和 MFA 身份验证。 所有这一切都建立在事件溯源之上，并结合 CQRS 来提供出色的审计跟踪。


### PR DESCRIPTION
## What

Add [Cloud-IAM](https://cloud-iam.com) to the **OAuth2 & OpenID** section.

## Why this resource is awesome

Cloud-IAM is a managed Keycloak SaaS platform founded in 2019 in Europe, with a 100% in-house European team. It differs from self-hosted Keycloak by offering:

- **Multi-cloud availability**: 70+ regions across 5 cloud providers (AWS, GCP, Azure, Outscale, Scaleway)
- **Strong compliance posture**: ISO 27001:2022, SOC 2 Type 2, NIS 2, GDPR, HDS (health data hosting), and SecNumCloud 3.2 certified
- **Production-proven**: 500+ customers, 20M+ users managed

It complements the existing Keycloak entry (self-hosted open-source) by providing a managed, compliance-ready alternative — similar to how other sections list both open-source tools and their managed counterparts.

Changes propagated to `readme.zh.md` as per contribution guidelines.