### PR TITLE
add authsome under Secret Management

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -487,6 +487,8 @@ Architectures, software and hardware allowing the storage and usage of secrets t
 
 - [`trufflehog`](https://github.com/trufflesecurity/trufflehog) - 💸 Searches through Git repositories for high entropy strings and secrets, digging deep into commit history.
 
+- [`authsome`](https://github.com/agentrhq/authsome) - 🆓 Local credential broker for AI agents. Log in once via OAuth2 (browser PKCE / device code) or API key, encrypted vault stores credentials under `~/.authsome`, a local HTTPS proxy on loopback injects them at request time so the agent's process environment never holds raw secrets. 45 providers bundled (14 OAuth2, 31 API key) including GitHub, Google, OpenAI, Linear, Slack, Notion, Resend, Stripe. Background token refresh. MIT.
+
 ### Hardware Security Module (HSM)
 
 HSMs are physical devices guaranteeing security of secret management at the hardware level.


### PR DESCRIPTION
hey, opening this to add authsome under Secret Management.

authsome is an open-source local credential broker built specifically for AI agents. log in once via OAuth2 (browser PKCE or device code) or API key, the encrypted vault sits under ~/.authsome, and a local HTTPS proxy on loopback injects credentials into outbound provider requests so the agent's process environment never holds raw secrets. 45 providers bundled (14 OAuth2, 31 API key) including GitHub, Google, OpenAI, Linear, Slack, Notion, Resend, Stripe. background token refresh, no SaaS dependency.

it fits in Secret Management because the core problem authsome solves is the same as Vault / sops / Infisical, just scoped to a different consumer (AI agents calling external SaaS APIs rather than humans or services calling internal infra). marked 🆓 since it's MIT and Python.

also reasonable in OAuth2 & OpenID since the OAuth2 flows are first-class — happy to move it if you prefer that section, or to split into two entries.

repo: https://github.com/agentrhq/authsome
website: https://authsome.ai
license: MIT
pypi: https://pypi.org/project/authsome/ (0.3.2)