### PR TITLE
Add Nutilz JWT Decoder to JWT section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -326,6 +326,8 @@ Certificate-based authentication.
 
 - [JWT.io](https://jwt.io) - Allows you to decode, verify and generate JWT.
 
+- [Nutilz JWT Decoder](https://nutilz.com/jwt-decoder) - 🆓 Decodes a JWT's header and payload, flags expired tokens, and converts timestamp claims to readable dates. Runs entirely client-side, so the token never leaves the browser.
+
 ## Authorization
 
 Now we know you are you. But are you allowed to do what you want to do?


### PR DESCRIPTION
Adds [Nutilz JWT Decoder](https://nutilz.com/jwt-decoder), a free client-side tool for decoding JWT header/payload, flagging expired tokens, and converting timestamp claims to readable dates. Nothing is sent to a server — decoding happens entirely in the browser.

Added it right next to the existing JWT.io entry since it serves the same purpose (decode/inspect JWTs).