### PR TITLE
Move Cerbos to ABAC frameworks and update its description

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -360,13 +360,13 @@ As a concept, access control policies can be designed to follow very different a
 
 - [Biscuit](https://www.clever-cloud.com/blog/engineering/2021/04/12/introduction-to-biscuit/) - Merges concepts from cookies, JWTs, macaroons and Open Policy Agent. “It provide a logic language based on Datalog to write authorization policies. It can store data, like JWT, or small conditions like Macaroons, but it is also able to represent more complex rules like role-based access control, delegation, hierarchies.”
 
-- [Cerbos](https://github.com/cerbos/cerbos) - 💸 An authorization endpoint to write context-aware access control policies.
-
 - [FerrisKey](https://github.com/ferriskey/ferriskey) - 🆓 Self-hosted, open-source, RBAC system written in Rust.
 
 ### ABAC frameworks
 
 [Attribute-Based Access Control](https://en.wikipedia.org/wiki/Attribute-based_access_control) is an evolution of RBAC, in which roles are replaced by attributes, allowing the implementation of more complex policy-based access control.
+
+- [Cerbos](https://github.com/cerbos/cerbos) - 💸 Runtime authorization layer implementing RBAC, ABAC and PBAC, with a managed control plane for authoring, testing and distributing policies. Fine-grained access control for apps, APIs, workloads and AI agents, built on an Apache-2.0 open-source core.
 
 - [Keto](https://github.com/ory/keto) - 💸 Policy decision point. It uses a set of access control policies, similar to AWS policies, in order to determine whether a subject is authorized to perform a certain action on a resource.
 

--- a/readme.zh.md
+++ b/readme.zh.md
@@ -360,13 +360,13 @@ IAM 的基础：用户、组、角色和权限的定义和生命周期。
 
 - [Biscuit](https://www.clever-cloud.com/blog/engineering/2021/04/12/introduction-to-biscuit/) - Biscuit 合并了来自 cookies、JWTs、macaroons 和 Open Policy Agent 的概念。 “它提供了一种基于 Datalog 的逻辑语言来编写授权策略。 它可以存储数据，如 JWT，或像 Macaroons 这样的小条件，但它也能够表示更复杂的规则，如基于角色的访问控制、委托、层次结构。”
 
-- [Cerbos](https://github.com/cerbos/cerbos) - 💸 用于编写上下文感知访问控制策略的授权端点。
-
 - [FerrisKey](https://github.com/ferriskey/ferriskey) - 🆓 用 Rust 编写的自托管、开源、RBAC 系统。
 
 ### ABAC 框架
 
 [Attribute-Based Access Control](https://en.wikipedia.org/wiki/Attribute-based_access_control) 是RBAC的演变，其中角色被属性取代，从而实现了更复杂的基于策略的访问控制。
+
+- [Cerbos](https://github.com/cerbos/cerbos) - 💸 运行时授权层，支持 RBAC、ABAC 和 PBAC，并提供用于编写、测试和分发策略的托管控制平面。为应用、API、工作负载和 AI 智能体提供细粒度访问控制，基于 Apache-2.0 开源内核构建。
 
 - [Keto](https://github.com/ory/keto) - 💸 策略决定点。 它使用一组访问控制策略，类似于 AWS 策略，以确定主体是否有权对资源执行特定操作。
 


### PR DESCRIPTION
### Motivation

Hey Kyle, I hope all is well!

Cerbos is currently listed under RBAC frameworks, but its model is attribute and policy based. Roles are one input among request and resource attributes evaluated in CEL conditions, which is what the ABAC section describes. This moves the existing entry and refreshes a description that predates the current feature set.

No new link, just a recategorization of one that is already curated.

### Affiliation

- [ ] I am the author of the article or project
- [x] I am working for/with the company publishing the article or project
- [ ] I'm just a rando who stumbled upon this via social networks

### Licensing marker

- [ ] My entry is an article/paper/curation list and is not marked
- [x] My entry is a tool/dataset/project marked with 💸 (commercial vendor)
- [ ] My entry is a tool/dataset/project marked with 🆓 (fully open-source)

### Self checks

- [x] I have read the Code of Conduct
- [x] I applied all rules from the Contributing guide
- [x] I checked there is no other Issues or Pull Requests covering the same topic
- [x] I applied the changes to all translatations in `readme.*.md` files