### PR TITLE
Add The Authorization Maturity Model to Authorization

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -340,6 +340,8 @@ As a concept, access control policies can be designed to follow very different a
 
 - [The never-ending product requirements of user authorization](https://alexolivier.me/posts/the-never-ending-product-requirements-of-user-authorization) - How a simple authorization model based on roles is not enough and gets complicated fast due to product packaging, data locality, enterprise organizations and compliance.
 
+- [The Authorization Maturity Model](https://solutions.cerbos.dev/authorization-maturity-model-a-cisos-benchmark) - A four-stage model for benchmarking an authorization program, from ad-hoc to governed, mapping the regulatory exposure of each stage and providing a 15-question self-assessment.
+
 - [RBAC like it was meant to be](https://tailscale.com/blog/rbac-like-it-was-meant-to-be/) - How we got from DAC (unix permissions, secret URL), to MAC (DRM, MFA, 2FA, SELinux), to RBAC. Details how the latter allows for better modeling of policies, ACLs, users and groups.
 
 - [The Case for Granular Permissions](https://cerbos.dev/blog/the-case-for-granular-permissions) - Discuss the limitations of RBAC and how ABAC (Attribute-Based Access Control) addresses them.

--- a/readme.zh.md
+++ b/readme.zh.md
@@ -340,6 +340,8 @@ IAM 的基础：用户、组、角色和权限的定义和生命周期。
 
 - [用户授权的永无止境的产品要求](https://alexolivier.me/posts/the-never-ending-product-requirements-of-user-authorization) - 基于角色的简单授权模型是如何不够的，并且由于产品包装、数据定位、企业组织和合规性而迅速变得复杂。
 
+- [授权成熟度模型](https://solutions.cerbos.dev/authorization-maturity-model-a-cisos-benchmark) - 一个四阶段模型，用于衡量授权体系从临时应对到规范治理的成熟度，映射每个阶段的合规风险，并提供一份 15 道题的自评估问卷。
+
 - [拟采用的 RBAC 方式](https://tailscale.com/blog/rbac-like-it-was-meant-to-be/) -我们如何从 DAC（unix 权限、秘密 URL）到 MAC（DRM、MFA、2FA、SELinux），再到 RBAC。 详细说明后者如何允许更好地建模策略、ACL、用户和组。
 
 - [细粒度权限的案例](https://cerbos.dev/blog/the-case-for-granular-permissions) - 讨论 RBAC 的局限性以及 ABAC（基于属性的访问控制）如何解决这些问题。


### PR DESCRIPTION
### Motivation

The Authorization section covers why authorization is hard and how to model it, but has nothing for assessing an existing program (yet). This is a four-stage model, ad-hoc to governed, that grades on production behaviour rather than documentation, maps each stage to NIS2, DORA, SEC and EU AI Act exposure, and includes a 15-question self-assessment.

It sits behind an email gate, and I work at the company publishing it. Close it if either is disqualifying.

### Affiliation

- [ ] I am the author of the article or project
- [x] I am working for/with the company publishing the article or project
- [ ] I'm just a rando who stumbled upon this via social networks

### Licensing marker

- [x] My entry is an article/paper/curation list and is not marked
- [ ] My entry is a tool/dataset/project marked with 💸 (commercial vendor)
- [ ] My entry is a tool/dataset/project marked with 🆓 (fully open-source)

### Self checks

- [x] I have read the Code of Conduct
- [x] I applied all rules from the Contributing guide
- [x] I checked there is no other Issues or Pull Requests covering the same topic
- [x] I applied the changes to all translatations in `readme.*.md` files