### PR TITLE
Add OpenID AuthZEN to Authorization

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -338,6 +338,8 @@ As a concept, access control policies can be designed to follow very different a
 
 - [Why Authorization is Hard](https://www.osohq.com/post/why-authorization-is-hard) - Because it needs multiple tradeoffs on Enforcement which is required in so many places, on Decision architecture to split business logic from authorization logic, and on Modeling to balance power and complexity.
 
+- [OpenID AuthZEN](https://openid.net/wg/authzen/) - An OpenID Foundation working group standardizing the API between policy enforcement points and policy decision points, so authorization can be externalized without locking into one vendor.
+
 - [The never-ending product requirements of user authorization](https://alexolivier.me/posts/the-never-ending-product-requirements-of-user-authorization) - How a simple authorization model based on roles is not enough and gets complicated fast due to product packaging, data locality, enterprise organizations and compliance.
 
 - [RBAC like it was meant to be](https://tailscale.com/blog/rbac-like-it-was-meant-to-be/) - How we got from DAC (unix permissions, secret URL), to MAC (DRM, MFA, 2FA, SELinux), to RBAC. Details how the latter allows for better modeling of policies, ACLs, users and groups.

--- a/readme.zh.md
+++ b/readme.zh.md
@@ -338,6 +338,8 @@ IAM 的基础：用户、组、角色和权限的定义和生命周期。
 
 - [为什么授权很难](https://www.osohq.com/post/why-authorization-is-hard) - 因为它需要在很多地方需要的执行、决策架构上进行多重权衡以将业务逻辑与授权逻辑分开，以及在建模上平衡功率和复杂性。
 
+- [OpenID AuthZEN](https://openid.net/wg/authzen/) - OpenID 基金会的工作组，致力于标准化策略执行点与策略决策点之间的 API，使授权可以外部化而不被单一供应商锁定。
+
 - [用户授权的永无止境的产品要求](https://alexolivier.me/posts/the-never-ending-product-requirements-of-user-authorization) - 基于角色的简单授权模型是如何不够的，并且由于产品包装、数据定位、企业组织和合规性而迅速变得复杂。
 
 - [拟采用的 RBAC 方式](https://tailscale.com/blog/rbac-like-it-was-meant-to-be/) -我们如何从 DAC（unix 权限、秘密 URL）到 MAC（DRM、MFA、2FA、SELinux），再到 RBAC。 详细说明后者如何允许更好地建模策略、ACL、用户和组。


### PR DESCRIPTION
### Motivation

AuthZEN is the OpenID Foundation working group standardizing the API between policy enforcement points and policy decision points. The specification was ratified in January 2026 and it is the first serious attempt at making authorization decisions interoperable across vendors, which the Authorization section does not currently reference anywhere.

This is a standards body page, not a vendor property.

### Affiliation

- [ ] I am the author of the article or project
- [x] I am working for/with the company publishing the article or project
- [ ] I'm just a rando who stumbled upon this via social networks

### Licensing marker

- [x] My entry is an article/paper/curation list and is not marked
- [ ] My entry is a tool/dataset/project marked with 💸 (commercial vendor)
- [ ] My entry is a tool/dataset/project marked with 🆓 (fully open-source)

### Self checks

- [x] I have read the Code of Conduct
- [x] I applied all rules from the Contributing guide
- [x] I checked there is no other Issues or Pull Requests covering the same topic
- [x] I applied the changes to all translatations in `readme.*.md` files