### PR TITLE
Add Entra Orchestrator to Security section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -124,6 +124,8 @@ Security is one of the most central pillar of IAM foundations. Here are some bro
 
 - [Cartography](https://github.com/lyft/cartography) - 🆓 A Neo4J-based tool to map out dependencies and relationships between services and resources. Supports AWS, GCP, GSuite, Okta and GitHub.
 
+- [Entra Orchestrator](https://github.com/Dfrank77/entra-orchestrator) - 🆓 Cross-tool correlation engine for Microsoft Entra ID security analysis. Connects findings from three independent scanners to surface privilege escalation paths and attack chains across single and multi-tenant environments.
+
 - [Open guide to AWS Security and IAM](https://github.com/open-guides/og-aws#security-and-iam)
 
 ## Account Management

--- a/readme.zh.md
+++ b/readme.zh.md
@@ -124,6 +124,8 @@
 
 - [Cartography](https://github.com/lyft/cartography) - 🆓 一种基于 Neo4J 的工具，用于映射服务和资源之间的依赖关系和关系。 支持 AWS、GCP、GSuite、Okta 和 GitHub。
 
+- [Entra Orchestrator](https://github.com/Dfrank77/entra-orchestrator) - 🆓 Microsoft Entra ID 安全分析的跨工具关联引擎。连接三个独立扫描器的发现，以发现跨单租户和多租户环境的权限提升路径和攻击链。
+
 - [AWS 安全性和 IAM 开放指南](https://github.com/open-guides/og-aws#security-and-iam)
 
 ## 账户管理


### PR DESCRIPTION
### Motivation

The list currently has zero entries covering Microsoft Entra ID (Azure AD) security tooling. AWS has a dedicated subsection with multiple tools (Policy Sentry, IAM Floyd, IAMbic). This adds the first Entra ID entry and fills that gap.

This repo is below the 50-star baseline. Requesting consideration under the niche exception: there is no equivalent open-source Entra ID security correlation tool on this list or in the broader OSS ecosystem. The tool is actively maintained and MIT licensed.

### Affiliation

- [x] I am the author of the article or project
- [ ] I am working for/with the company publishing the article or project
- [ ] I'm just a rando who stumbled upon this via social networks

### Licensing marker

- [ ] My entry is an article/paper/curation list and is not marked
- [ ] My entry is a tool/dataset/project marked with 💸 (commercial vendor)
- [x] My entry is a tool/dataset/project marked with 🆓 (fully open-source)

### Self checks

- [x] I have [read the Code of Conduct](https://github.com/kdeldycke/awesome-iam/blob/main/.github/code-of-conduct.md)
- [x] I applied all rules from the [Contributing guide](https://github.com/kdeldycke/awesome-iam/blob/main/.github/contributing.md)
- [x] I checked there is no other [Issues](https://github.com/kdeldycke/awesome-iam/issues) or [Pull Requests](https://github.com/kdeldycke/awesome-iam/pulls) covering the same topic
- [x] I applied the changes to all translatations in `readme.*.md` files