### PR TITLE
Fix Casdoor URL and refresh its description

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -452,7 +452,7 @@ The old *OpenID* is dead; the new *OpenID Connect* is very much not-dead.
 
 - [Keycloak](https://github.com/keycloak/keycloak) - 🆓 Open-source Identity and Access Management. Supports OIDC, OAuth 2 and SAML 2, LDAP and AD directories, password policies.
 
-- [Casdoor](https://github.com/casbin/casdoor) - 🆓 A UI-first centralized authentication / Single-Sign-On (SSO) platform based. Supports OIDC and OAuth 2, social logins, user management, 2FA based on Email and SMS.
+- [Casdoor](https://github.com/casdoor/casdoor) - 🆓 A UI-first centralized authentication / Single-Sign-On (SSO) platform. Supports OAuth 2, OIDC, SAML 2, CAS, LDAP and SCIM, social logins, user management, WebAuthn and TOTP/MFA.
 
 - [authentik](https://github.com/goauthentik/authentik) - 💸 Open-source Identity Provider similar to Keycloak.
 

--- a/readme.zh.md
+++ b/readme.zh.md
@@ -452,7 +452,7 @@ IAM 的基础：用户、组、角色和权限的定义和生命周期。
 
 - [Keycloak](https://github.com/keycloak/keycloak) - 🆓 开源的身份和访问管理。支持 OIDC、OAuth 2和SAML 2、LDAP 和 AD 目录、密码策略。
 
-- [Casdoor](https://github.com/casbin/casdoor) - 🆓 基于 UI 优先的集中式身份验证/单点登录 (SSO) 平台。 支持 OIDC 和 OAuth 2、社交登录、用户管理、基于电子邮件和短信的 2FA。
+- [Casdoor](https://github.com/casdoor/casdoor) - 🆓 UI 优先的集中式身份验证/单点登录 (SSO) 平台。支持 OAuth 2、OIDC、SAML 2、CAS、LDAP 和 SCIM，社交登录、用户管理、WebAuthn 和 TOTP/MFA。
 
 - [authentik](https://github.com/goauthentik/authentik) - 💸 类似于 Keycloak 的开源身份提供者。
 


### PR DESCRIPTION
### Motivation

The Casdoor entry points at `github.com/casbin/casdoor`, which is the old organization. The project moved to its own org years ago and now lives at [`github.com/casdoor/casdoor`](https://github.com/casdoor/casdoor) — the old URL only survives as a GitHub redirect.

While fixing the link, the description is also refreshed: it said "OIDC and OAuth 2 … 2FA based on Email and SMS", which predates SAML 2, CAS, LDAP, SCIM, WebAuthn and TOTP support. The stray word "based" at the end of the sentence is dropped too.

Applied to both `readme.md` and `readme.zh.md`. The 🆓 marker is unchanged: Casdoor is Apache-2.0 with no feature gating — the vendor sells managed hosting only, which per the contributing guide keeps it 🆓.

### Affiliation

- [x] I am the author of the article or project
- [ ] I am working for/with the company publishing the article or project
- [ ] I'm just a rando who stumbled upon this via social networks

### Licensing marker

- [ ] My entry is an article/paper/curation list and is not marked
- [ ] My entry is a tool/dataset/project marked with 💸 (commercial vendor)
- [x] My entry is a tool/dataset/project marked with 🆓 (fully open-source)

### Self checks

- [x] I have read the Code of Conduct
- [x] I applied all rules from the Contributing guide
- [x] I checked there is no other Issues or Pull Requests covering the same topic
- [x] I applied the changes to all translatations in `readme.*.md` files